### PR TITLE
Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+playwright-report

--- a/src/common/hooks.ts
+++ b/src/common/hooks.ts
@@ -1,24 +1,20 @@
 export class Hooks {
+  // Lifecycle based hooks
 
-    // Lifecycle based hooks
+  beforeStep?: (...args: any[]) => any;
+  afterStep?: (...args: any[]) => any;
 
-    beforeAutomation?: (...args: any[]) => any
-    afterAutomation?: (...args: any[]) => any
-    
+  // Tag based hooks
 
-    // Tag based hooks
+  private _tagBased: {
+    [tag: string]: (...args: any[]) => any;
+  } = {};
 
-    private _tagBased: {
-        [tag: string]: (...args: any[]) => any,
-    } = {}
+  beforeTag(tag: string, callback: (...args: any[]) => any) {
+    this._tagBased[tag] = callback;
+  }
 
-
-    on(tag: string, callback: (...args: any[]) => any) {
-        this._tagBased[tag] = callback
-    }
-
-    trigger(tag: string, ...args: any[]) {
-        return this._tagBased[tag]?.(...args)
-    }
-
+  triggerTag(tag: string, ...args: any[]) {
+    return this._tagBased[tag]?.(...args);
+  }
 }

--- a/src/common/hooks.ts
+++ b/src/common/hooks.ts
@@ -1,0 +1,24 @@
+export class Hooks {
+
+    // Lifecycle based hooks
+
+    beforeAutomation?: (...args: any[]) => any
+    afterAutomation?: (...args: any[]) => any
+    
+
+    // Tag based hooks
+
+    private _tagBased: {
+        [tag: string]: (...args: any[]) => any,
+    } = {}
+
+
+    on(tag: string, callback: (...args: any[]) => any) {
+        this._tagBased[tag] = callback
+    }
+
+    trigger(tag: string, ...args: any[]) {
+        return this._tagBased[tag]?.(...args)
+    }
+
+}

--- a/src/common/library.ts
+++ b/src/common/library.ts
@@ -10,7 +10,7 @@ export type TestFunction<T> = (frameworkArgs: T, wrapperArgs: WrapperArgs) => an
 
 type TestSpecs<T> = {
   spec: string | RegExp;
-  test: TestFunction<T>;
+  fn: TestFunction<T>;
 };
 
 export function usableStepType(
@@ -44,22 +44,22 @@ export class Library<T> {
     [StepKeywordType.OUTCOME]: [],
   };
 
-  public given(spec: string | RegExp, test: TestFunction<T>) {
-    this._storage[StepKeywordType.CONTEXT].push({ spec, test });
+  public given(spec: string | RegExp, fn: TestFunction<T>) {
+    this._storage[StepKeywordType.CONTEXT].push({ spec, fn });
   }
 
-  public when(spec: string | RegExp, test: TestFunction<T>) {
-    this._storage[StepKeywordType.ACTION].push({ spec, test });
+  public when(spec: string | RegExp, fn: TestFunction<T>) {
+    this._storage[StepKeywordType.ACTION].push({ spec, fn });
   }
 
-  public then(spec: string | RegExp, test: TestFunction<T>) {
-    this._storage[StepKeywordType.OUTCOME].push({ spec, test });
+  public then(spec: string | RegExp, fn: TestFunction<T>) {
+    this._storage[StepKeywordType.OUTCOME].push({ spec, fn });
   }
 
   public find(
     type: StepKeywordType.CONTEXT | StepKeywordType.ACTION | StepKeywordType.OUTCOME | undefined,
     spec: string,
-  ): { test?: TestFunction<T>; wrapperArgs: WrapperArgs } {
+  ): { fn?: TestFunction<T>; wrapperArgs: WrapperArgs } {
     const _default = { wrapperArgs: {} };
 
     if (!type) return _default;
@@ -69,7 +69,7 @@ export class Library<T> {
     });
     if (!item) return _default;
     return {
-      test: item.test,
+      fn: item.fn,
       wrapperArgs: {
         match: spec.match(item.spec) as RegExpMatchArray,
       },

--- a/src/common/wrapper.ts
+++ b/src/common/wrapper.ts
@@ -4,42 +4,45 @@ import { parse } from './parser';
 import { Hooks } from './hooks';
 
 export interface BaseWrapperOptions<TestArgs> {
-  library?: Library<TestArgs>,
-  hooks?: Hooks,
+  library?: Library<TestArgs>;
+  hooks?: Hooks;
 }
 
-export abstract class Wrapper<TestArgs, WrapperOptions extends BaseWrapperOptions<TestArgs> = BaseWrapperOptions<TestArgs>> {
+export abstract class Wrapper<
+  TestArgs,
+  WrapperOptions extends BaseWrapperOptions<TestArgs> = BaseWrapperOptions<TestArgs>,
+> {
   readonly library = new Library<TestArgs>();
   readonly hooks = new Hooks();
-  
+
   constructor(options: WrapperOptions = {} as WrapperOptions) {
-    if (options.library) this.library = options.library
-    if (options.hooks) this.hooks = options.hooks
+    if (options.library) this.library = options.library;
+    if (options.hooks) this.hooks = options.hooks;
   }
 
   get given(): typeof this.library.given {
-    return this.library.given.bind(this.library)
+    return this.library.given.bind(this.library);
   }
   get when(): typeof this.library.when {
-    return this.library.when.bind(this.library)
+    return this.library.when.bind(this.library);
   }
   get then(): typeof this.library.then {
-    return this.library.then.bind(this.library)
+    return this.library.then.bind(this.library);
   }
 
-  get on() {
-    return this.hooks.on.bind(this.hooks)
+  get beforeTag() {
+    return this.hooks.beforeTag.bind(this.hooks);
   }
-  get trigger() {
-    return this.hooks.trigger.bind(this.hooks)
+  protected get triggerTag() {
+    return this.hooks.triggerTag.bind(this.hooks);
   }
-  beforeAutomation(callback: (...args: any[]) => any) {
-    this.hooks.beforeAutomation = callback
+  beforeStep(callback: (...args: any[]) => any) {
+    this.hooks.beforeStep = callback;
   }
-  afterAutomation(callback: (...args: any[]) => any) {
-    this.hooks.afterAutomation = callback
+  afterStep(callback: (...args: any[]) => any) {
+    this.hooks.afterStep = callback;
   }
-  
+
   protected getTestFunction(step: Step, prevStepType: Parameters<typeof this.library.find>[0]) {
     const keywordType = usableStepType(step.keywordType, prevStepType);
     return {
@@ -47,7 +50,7 @@ export abstract class Wrapper<TestArgs, WrapperOptions extends BaseWrapperOption
       keywordType,
     };
   }
-  
+
   public test(filePath: string, encoding?: BufferEncoding) {
     const gherkinDocument = parse(filePath, encoding);
     if (gherkinDocument.feature) this.runFeature(gherkinDocument.feature);

--- a/tests/complexe.feature
+++ b/tests/complexe.feature
@@ -13,6 +13,7 @@ Feature: Web page
   Background: Using chrome inside
   Given the browser is "chrome"
 
+    @skip
     Scenario Outline: Has expected title
       Given i am on the <url> website home page
       Then the page title should contain <title>
@@ -22,10 +23,10 @@ Feature: Web page
         | playwright.dev | Playwright |
         | www.google.com | Google |
         
-  @depreciated
-  Scenario: Google.com has expected title
-    Given i am on the "www.google.com" website home page
-    Then the page title should contain "Google"
+    @depreciated
+    Scenario: Google.com has expected title
+      Given i am on the "www.google.com" website home page
+      Then the page title should contain "Google"
 
   @more
   Example: Loading data

--- a/tests/playwright/complexe.spec.ts
+++ b/tests/playwright/complexe.spec.ts
@@ -4,7 +4,7 @@ import GherkinWrapper from "../../src";
 
 const wrapper = new GherkinWrapper.forPlaywright(test)
 
-wrapper.on('@skip', () => {
+wrapper.beforeTag('@skip', () => {
     test.skip(true, 'Tagged @skip')
 })
 

--- a/tests/playwright/complexe.spec.ts
+++ b/tests/playwright/complexe.spec.ts
@@ -1,15 +1,20 @@
 import { Page, test } from "@playwright/test";
 import GherkinWrapper from "../../src";
 
+
 const wrapper = new GherkinWrapper.forPlaywright(test)
 
+wrapper.on('@skip', () => {
+    test.skip(true, 'Tagged @skip')
+})
+
 const defaultHandler = async ({page}: {page: Page}, wrapperArgs) => {
-    console.log(JSON.stringify(wrapperArgs, null, 2))
+    //console.log(JSON.stringify(wrapperArgs, null, 2))
     await page.waitForTimeout(1000)
 }
 
 wrapper.given(/.*/, defaultHandler)
 wrapper.when(/.*/, defaultHandler)
-wrapper.then(/.*/, defaultHandler)
+//wrapper.then(/.*/, defaultHandler)
 
 wrapper.test('./tests/complexe.feature')

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
 
   // Reporter to use
-  reporter: 'list',
+  reporter: 'html',
 
   use: {
   },

--- a/tests/playwright/simple.spec.ts
+++ b/tests/playwright/simple.spec.ts
@@ -1,23 +1,24 @@
-import { test as base } from "@playwright/test";
+import { test as base, expect } from "@playwright/test";
 import GherkinWrapper from "../../src/";
 
 
 const test = base.extend<{value: string}>({
     value: async ({}, use) => {
-        console.log('fixture is being loaded')
+        //console.log('fixture is being loaded')
         await use('go')
     }
 })
 
-const wrapper = new GherkinWrapper.forPlaywright(base)
+const wrapper = new GherkinWrapper.forPlaywright(test)
 
 wrapper.when("the Maker starts a game", () => {})
 wrapper.then("the Maker waits for a Breaker to join", () => {})
 
-wrapper.given(/the Maker has started a game with the word "(.*)"/, async ({ page }, { match }) => {
-    console.log('fixture is being used')
-    console.log(match)
+wrapper.given(/the Maker has started a game with the word "(.*)"/, async ({ page, value }, { match }) => {
+    //console.log('fixture is being used')
+    //console.log(match)
     await page.goto('https://www.google.com/')
+    expect(value).toBe('go')
 })
 
 wrapper.when(/the Breaker.*/, () => {})


### PR DESCRIPTION
**Add ability to register hooks**

- `beforeAutomation` and `afterAutomation` hooks: ran from the `test.step` scope, just before and after each step function call
- `on` "tag" hook: run in the `test.describe`/`test` call scope, just before the feature/rule/background/scenario begins

```typescript
const wrapper = new GherkinWrapper.forPlaywright(test)

wrapper.beforeAutomation((state: {step: Step, fn: TestFunction, runnerArg: RunnerArg, wrapperArg: WrapperArg}) => {
  test.skip(!fn, 'Not yet automated')
})

wrapper.on('@shouldFail', () => {
  test.fail()
})
```

