### PR TITLE
Allow a library with fewer fixtures to be used with a test that requires more fixtures

### DIFF
--- a/src/common/library.ts
+++ b/src/common/library.ts
@@ -8,7 +8,10 @@ export type WrapperArgs = {
   docString?: DocString['content'];
 };
 
-export type TestFunction<T> = (frameworkArgs: T, wrapperArgs: WrapperArgs) => any;
+export type TestFunction<T> = (
+  frameworkArgs: T & { [key: string | number | symbol]: any },
+  wrapperArgs: WrapperArgs,
+) => any;
 
 type TestSpecs<T> = {
   spec: string | RegExp;

--- a/src/common/library.ts
+++ b/src/common/library.ts
@@ -8,10 +8,13 @@ export type WrapperArgs = {
   docString?: DocString['content'];
 };
 
-export type TestFunction<T> = (
-  frameworkArgs: T & { [key: string | number | symbol]: any },
-  wrapperArgs: WrapperArgs,
-) => any;
+type KeyValue = { [k: string | number | symbol]: any };
+
+type WithDefault<Base, Default> = {
+  [K in keyof (Base & Omit<KeyValue, keyof Base>)]: K extends keyof Base ? Base[K] : Default;
+};
+
+export type TestFunction<Base> = (frameworkArgs: WithDefault<Base, undefined>, wrapperArgs: WrapperArgs) => any;
 
 type TestSpecs<T> = {
   spec: string | RegExp;

--- a/src/common/wrapper.ts
+++ b/src/common/wrapper.ts
@@ -3,19 +3,16 @@ import { Background, Feature, Rule, Scenario, Step } from '@cucumber/messages';
 import { parse } from './parser';
 import { Hooks } from './hooks';
 
-export interface BaseWrapperOptions<TestArgs> {
-  library?: Library<TestArgs>;
+export interface BaseWrapperOptions {
+  library?: Library<any>;
   hooks?: Hooks;
 }
 
-export abstract class Wrapper<
-  TestArgs,
-  WrapperOptions extends BaseWrapperOptions<TestArgs> = BaseWrapperOptions<TestArgs>,
-> {
+export abstract class Wrapper<TestArgs, Options extends BaseWrapperOptions = BaseWrapperOptions> {
   readonly library = new Library<TestArgs>();
   readonly hooks = new Hooks();
 
-  constructor(options: WrapperOptions = {} as WrapperOptions) {
+  constructor(options: Options = {} as Options) {
     if (options.library) this.library = options.library;
     if (options.hooks) this.hooks = options.hooks;
   }

--- a/src/wrappers/playwright.ts
+++ b/src/wrappers/playwright.ts
@@ -109,7 +109,7 @@ class Wrapper<T extends BaseTestRunner> extends Base<TestArgs<T>> {
   protected async runStep(args: StepRunnerArgs<TestArgs<T>>) {
     await this.testRunner.step(args.step.keyword + args.step.text, async () => {
       await this.hooks.beforeStep?.(args);
-      await args.fn?.(args.runnerArgs, {
+      await args.fn?.(args.runnerArgs as Parameters<TestFunction<TestArgs<T>>>[0], {
         ...args.wrapperArgs,
         rawdataTable: args.step.dataTable,
         dataTable: args.step.dataTable ? new DataTable(args.step.dataTable) : undefined,

--- a/src/wrappers/playwright.ts
+++ b/src/wrappers/playwright.ts
@@ -20,9 +20,11 @@ interface StepRunnerArgs<T extends TestArgs<BaseTestRunner>> {
 
 class Wrapper<T extends BaseTestRunner> extends Base<TestArgs<T>> {
   private testRunner: T;
+  private readonly sym: symbol;
 
-  constructor(testRunner: T, options?: BaseWrapperOptions<TestArgs<T>>) {
+  constructor(testRunner: T, options?: BaseWrapperOptions) {
     super(options);
+    this.sym = Reflect.ownKeys(testRunner).find((key) => key.toString() === 'Symbol(testType)') as symbol;
     this.testRunner = testRunner;
     if (!this.hooks.beforeStep)
       this.hooks.beforeStep = (args: StepRunnerArgs<TestArgs<T>>) => {
@@ -124,14 +126,14 @@ class Wrapper<T extends BaseTestRunner> extends Base<TestArgs<T>> {
   }
 
   private buildFixtureProvider(steps: { fn?: TestFunction<TestArgs<T>> }[]): FixtureProvider<T> {
+    // @ts-expect-error access to playwright internal testTypeImplementation
+    const availableFixtures: string[] = this.testRunner[this.sym].fixtures.flatMap((value) =>
+      Object.keys(value.fixtures),
+    );
     const requiredFixtureNames =
       '{' +
       [
-        ...new Set(
-          steps
-            .map(({ fn }) => fixtureParameterNames(fn))
-            .reduce((list, fixtureNames) => list.concat(fixtureNames), []),
-        ),
+        ...new Set(steps.flatMap(({ fn }) => fixtureParameterNames(fn)).filter((f) => availableFixtures.includes(f))),
       ].join(',') +
       '}';
     return new Function(
@@ -145,11 +147,9 @@ export default Wrapper;
 
 // playwright functions to identify fixture parameters
 
-const signatureSymbol = Symbol('signature');
 function fixtureParameterNames(fn: any) {
   if (typeof fn !== 'function') return [];
-  if (!fn[signatureSymbol]) fn[signatureSymbol] = innerFixtureParameterNames(fn);
-  return fn[signatureSymbol];
+  return innerFixtureParameterNames(fn);
 }
 function innerFixtureParameterNames(fn: (...args: any[]) => any) {
   const text = filterOutComments(fn.toString());

--- a/tests/playwright/complexe.spec.ts
+++ b/tests/playwright/complexe.spec.ts
@@ -10,7 +10,7 @@ wrapper.beforeTag('@skip', () => {
     test.skip(true, 'Tagged @skip')
 })
 
-const defaultHandler = async ({page}: {page: Page}, {dataTable, rawdataTable}: {dataTable?: DataTable, rawdataTable?: RawDataTable}) => {
+const defaultHandler = async ({page, fake}: {page: Page, fake?}, {dataTable, rawdataTable}: {dataTable?: DataTable, rawdataTable?: RawDataTable}) => {
     if (dataTable) console.log(dataTable.raw(), rawdataTable)
     await page.waitForTimeout(1000)
 }

--- a/tests/playwright/simple.spec.ts
+++ b/tests/playwright/simple.spec.ts
@@ -11,10 +11,12 @@ const test = base.extend<{value: string}>({
 
 const wrapper = new GherkinWrapper.forPlaywright(test)
 
+const anotherWrapper = new GherkinWrapper.forPlaywright(base, {library: wrapper.library})
+
 wrapper.when("the Maker starts a game", () => {})
 wrapper.then("the Maker waits for a Breaker to join", () => {})
 
-wrapper.given(/the Maker has started a game with the word "(.*)"/, async ({ page, value }, { match }) => {
+wrapper.given(/the Maker has started a game with the word "(.*)"/, async ({ page, value, fake }, { match }) => {
     //console.log('fixture is being used')
     //console.log(match)
     await page.goto('https://www.google.com/')

--- a/tests/playwright/simple.spec.ts
+++ b/tests/playwright/simple.spec.ts
@@ -1,8 +1,12 @@
 import { test as base, expect } from "@playwright/test";
 import GherkinWrapper from "../../src/";
 
+interface fixture {
+    /** A simple text value */
+    value: string
+}
 
-const test = base.extend<{value: string}>({
+const test = base.extend<fixture>({
     value: async ({}, use) => {
         await use('go')
     }
@@ -10,7 +14,6 @@ const test = base.extend<{value: string}>({
 
 const wrapper = new GherkinWrapper.forPlaywright(test)
 
-const anotherWrapper = new GherkinWrapper.forPlaywright(base, {library: wrapper.library})
 
 wrapper.when("the Maker starts a game", () => {})
 wrapper.then("the Maker waits for a Breaker to join", () => {})
@@ -23,4 +26,7 @@ wrapper.given(/the Maker has started a game with the word "(.*)"/, async ({ page
 wrapper.when(/the Breaker.*/, () => {})
 wrapper.then(/the Breaker.*/, () => {})
 
-wrapper.test('./tests/simple.feature')
+
+const anotherWrapper = new GherkinWrapper.forPlaywright(base, {library: wrapper.library})
+
+anotherWrapper.test('./tests/simple.feature')


### PR DESCRIPTION
 Replace #12 

Example:
```typescript
import { test as base, expect } from "@playwright/test";
import GherkinWrapper from "gherkin-wrapper";


const test = base.extend<{value: string}>({
    value: async ({}, use) => {
        await use(...)
    }
})

const wrapper = new GherkinWrapper.forPlaywright(test)

const anotherWrapper = new GherkinWrapper.forPlaywright(base, {library: wrapper.library}) // works

wrapper.given(/.*/, async ({ page, value, fake }, { match }) => {
    // fake is undefined
})
```